### PR TITLE
Update BitLocker Drive Encryption (BDE) format.asciidoc

### DIFF
--- a/documentation/BitLocker Drive Encryption (BDE) format.asciidoc
+++ b/documentation/BitLocker Drive Encryption (BDE) format.asciidoc
@@ -389,7 +389,7 @@ size and consists of:
 | *28* | *4* | | [yellow-background]*Number of hidden sectors* +
 Contains the volume start sector number
 | 32 | 4 | 0x00 | Total number of sectors (32-bit) 
-| *36* | *4* | *0x1f0e* | [yellow-background]*Sectors per file allocation table*
+| *36* | *4* | *0x1fe0* | [yellow-background]*Sectors per file allocation table*
 | *40* | *2* | | [yellow-background]*FAT Flags (Only used during a conversion from a FAT12/16 volume.)*
 | *42* | *2* | | [yellow-background]*Version (Defined as 0)*
 | *44* | *4* | | [yellow-background]*Cluster number of root directory start*


### PR DESCRIPTION
Reading my bitlocker partition at offset 0x24(36) gave me "e01f 0000" that's 0x1fe0 if converting the endianness

Not sure if this is always the same, because i only have one image to test on.
The image was generated on win10 with compatibility mode.