### PR TITLE
Increase metadata read size from 8K to 16K

### DIFF
--- a/libbde/libbde_metadata.c
+++ b/libbde/libbde_metadata.c
@@ -256,7 +256,7 @@ int libbde_metadata_read_block(
 	void *reallocation                       = NULL;
 	static char *function                    = "libbde_metadata_read_block";
 	size_t fve_metadata_block_offset         = 0;
-	size_t read_size                         = 8192;
+	size_t read_size                         = 16384;
 	ssize_t read_count                       = 0;
 	uint64_t first_metadata_offset           = 0;
 	uint64_t second_metadata_offset          = 0;


### PR DESCRIPTION
Some volumes have too much metadata for 8K, which then fail in strange
ways (e.g. FVEK not found)