### PR TITLE
Accept FVE header version 5

### DIFF
--- a/libbde/libbde_metadata_entry.c
+++ b/libbde/libbde_metadata_entry.c
@@ -250,7 +250,8 @@ ssize_t libbde_metadata_entry_read(
 #endif /* defined( HAVE_DEBUG_OUTPUT ) */
 
 	if( ( version != 1 )
-	 && ( version != 3 ) )
+		&& ( version != 3 )
+		&& ( version != 5 ) )
 	{
 		libcerror_error_set(
 		 error,


### PR DESCRIPTION
We came across some systems where FVE metadata version is 5. Only 1 and 3 was supported by libbde, but adding 5 to the accepted values seem to work correctly in all our tests.