### PR TITLE
Support for recovering the 48-digit recovery password.

### DIFF
--- a/bdetools/bdeinfo.c
+++ b/bdetools/bdeinfo.c
@@ -34,6 +34,10 @@
 #include <stdlib.h>
 #endif
 
+#if defined( WINAPI )
+#include <io.h>
+#endif
+
 #include "bdetools_getopt.h"
 #include "bdetools_libbde.h"
 #include "bdetools_libcerror.h"

--- a/bdetools/info_handle.c
+++ b/bdetools/info_handle.c
@@ -1127,7 +1127,7 @@ int info_handle_open(
 
 		if( bdetools_prompt_for_password(
 		     stdout,
-		     "Password",
+		     _SYSTEM_STRING( "Password" ),
 		     password,
 		     64,
 		     error ) != 1 )
@@ -2020,6 +2020,28 @@ int info_handle_volume_fprint(
 			 info_handle->notify_stream,
 			 "\n" );
 		}
+	}
+	{
+		uint8_t recovered_recovery_password[ 56 ];
+
+		if( libbde_volume_get_utf8_recovered_recovery_password(
+		     info_handle->volume,
+		     recovered_recovery_password,
+		     56,
+		     error ) == 1 )
+		{
+			if( recovered_recovery_password[ 0 ] != 0 )
+			{
+				fprintf(
+				 info_handle->notify_stream,
+				 "\tRecovered recovery password:\t%s\n",
+				 recovered_recovery_password );
+			}
+		}
+		memory_set(
+		 recovered_recovery_password,
+		 0,
+		 56 );
 	}
 	return( 1 );
 

--- a/include/libbde.h.in
+++ b/include/libbde.h.in
@@ -398,6 +398,18 @@ int libbde_volume_get_utf16_description(
      size_t utf16_string_size,
      libbde_error_t **error );
 
+/* Retrieves the UTF-8 string value of the recovered recovery password
+ * The recovered recovery password is derived from the VMK after successful unlock
+ * The size should include the end of string character
+ * Returns 1 if successful, 0 if not or -1 on error
+ */
+LIBBDE_EXTERN \
+int libbde_volume_get_utf8_recovered_recovery_password(
+     libbde_volume_t *volume,
+     uint8_t *utf8_string,
+     size_t utf8_string_size,
+     libbde_error_t **error );
+
 /* Retrieves the number of volume master key protectors
  * Returns 1 if successful or -1 on error
  */

--- a/libbde/libbde_metadata.c
+++ b/libbde/libbde_metadata.c
@@ -2265,6 +2265,8 @@ int libbde_metadata_read_full_volume_encryption_key(
      size_t full_volume_encryption_key_size,
      uint8_t *tweak_key,
      size_t tweak_key_size,
+     uint8_t *vmk_bytes_out,
+     size_t vmk_bytes_out_size,
      libcerror_error_t **error )
 {
 	uint8_t *unencrypted_data      = NULL;
@@ -2386,6 +2388,28 @@ int libbde_metadata_read_full_volume_encryption_key(
 		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
 		 LIBCERROR_ARGUMENT_ERROR_VALUE_TOO_SMALL,
 		 "%s: invalid TWEAK key value too small.",
+		 function );
+
+		return( -1 );
+	}
+	if( vmk_bytes_out == NULL )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_INVALID_VALUE,
+		 "%s: invalid VMK bytes out.",
+		 function );
+
+		return( -1 );
+	}
+	if( vmk_bytes_out_size < 32 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_VALUE_TOO_SMALL,
+		 "%s: invalid VMK bytes out value too small.",
 		 function );
 
 		return( -1 );
@@ -2579,6 +2603,20 @@ int libbde_metadata_read_full_volume_encryption_key(
 				 LIBCERROR_ERROR_DOMAIN_MEMORY,
 				 LIBCERROR_MEMORY_ERROR_COPY_FAILED,
 				 "%s: unable to copy unencrypted full volume encryption key.",
+				 function );
+
+				goto on_error;
+			}
+			if( memory_copy(
+			     vmk_bytes_out,
+			     &( unencrypted_data[ 28 ] ),
+			     32 ) == NULL )
+			{
+				libcerror_error_set(
+				 error,
+				 LIBCERROR_ERROR_DOMAIN_MEMORY,
+				 LIBCERROR_MEMORY_ERROR_COPY_FAILED,
+				 "%s: unable to copy VMK bytes out.",
 				 function );
 
 				goto on_error;

--- a/libbde/libbde_metadata.h
+++ b/libbde/libbde_metadata.h
@@ -169,6 +169,8 @@ int libbde_metadata_read_full_volume_encryption_key(
      size_t full_volume_encryption_key_size,
      uint8_t *tweak_key,
      size_t tweak_key_size,
+     uint8_t *vmk_bytes_out,
+     size_t vmk_bytes_out_size,
      libcerror_error_t **error );
 
 int libbde_metadata_get_volume_identifier(

--- a/libbde/libbde_recovery.c
+++ b/libbde/libbde_recovery.c
@@ -30,6 +30,8 @@
 #include "libbde_libcnotify.h"
 #include "libbde_libfvalue.h"
 #include "libbde_libhmac.h"
+#include "libbde_password.h"
+#include "libbde_password_keep.h"
 #include "libbde_recovery.h"
 
 /* Calculates the SHA256 hash of an UTF-8 formatted recovery password
@@ -462,25 +464,192 @@ on_error:
 	return( -1 );
 }
 
-/* Recovers the recovery password from metadata using the plain VMK bytes
- * Returns 1 if successful, 0 if the recovery password VMK entry is not present or -1 on error
+/* Helper: try to decrypt a sub-entry from the RP VMK stretch_key->data using
+ * the given 32-byte AES key and nonce.  Tries both without and with a 16-byte
+ * dummy prefix (to skip counter=0 / A0 in libcaes_crypt_ccm).
+ *
+ * sub_data      : pointer to the first byte of sub-entry data AFTER the 8-byte header
+ *                 (i.e. at offset +8 within the sub-entry: 12-byte nonce then ciphertext)
+ * ct_size       : number of ciphertext bytes (not counting the nonce header)
+ * aes_key       : 32-byte AES-256 key
+ * label         : short string for diagnostics (e.g. "E1" = sub-entry 1)
+ * found_rp_out  : if a valid RP is found, its 16 binary bytes are written here
+ * Returns 1 if a valid binary RP was found, 0 otherwise.
+ */
+static int rp_try_decrypt(
+     libcaes_context_t *aes_context,
+     const uint8_t *sub_data,
+     size_t ct_size,
+     const char *label,
+     uint8_t *found_rp_out,
+     libcerror_error_t **error )
+{
+	/* Max buffer: 16 dummy + up to 60 real = 76 bytes */
+	uint8_t ciphertext[ 76 ];
+	uint8_t plaintext[ 76 ];
+	uint8_t nonce[ 12 ];
+	int pass;
+	int segment_index;
+	int is_valid;
+	size_t try_sizes[ 2 ];
+	size_t rp_offsets[ 4 ];
+	size_t n_offsets;
+	size_t k;
+	uint16_t binary_rp_word;
+	uint32_t segment_value;
+	int result;
+	int _di;
+
+	if( ct_size > 60 || ct_size < 16 )
+	{
+		return( 0 );
+	}
+
+	/* nonce is first 12 bytes of sub_data */
+	if( memory_copy( nonce, sub_data, 12 ) == NULL ) return( 0 );
+
+	/* ciphertext starts at sub_data+12 */
+	/* pass 0: no dummy prefix — real data at counter=0 */
+	/* pass 1: 16-byte dummy prefix — real data at counter=1 (A1) */
+	for( pass = 0; pass <= 1; pass++ )
+	{
+		size_t prefix      = (size_t) pass * 16;
+		size_t total       = prefix + ct_size;
+
+		if( total > 76 ) continue;
+
+		if( memory_set( ciphertext, 0, total ) == NULL ) return( 0 );
+		if( memory_set( plaintext,  0, total ) == NULL ) return( 0 );
+
+		if( memory_copy( &( ciphertext[ prefix ] ), &( sub_data[ 12 ] ), ct_size ) == NULL )
+			return( 0 );
+
+		result = libcaes_crypt_ccm(
+		          aes_context,
+		          LIBCAES_CRYPT_MODE_DECRYPT,
+		          nonce,
+		          12,
+		          ciphertext,
+		          total,
+		          plaintext,
+		          total,
+		          error );
+
+		if( result != 1 )
+		{
+			libcerror_error_free( error );
+			continue;
+		}
+
+		/* The binary RP sits at a fixed offset within the plaintext.
+		 * Structure (for pass=0, ct_size=44):
+		 *   bytes  0..15 : GUID / random (16 bytes)
+		 *   bytes 16..27 : structure header (12 bytes)
+		 *                    [0..3]  = size LE (e.g. 2C 00 00 00)
+		 *                    [4..7]  = 01 00 00 00
+		 *                    [8..11] = ?? 10|20 00 00
+		 *   bytes 28..43 : binary RP (16 bytes)  <-- our target
+		 *
+		 * Try offset 28 first (definitive), then fallback to other offsets.
+		 */
+		n_offsets = 0;
+		rp_offsets[ n_offsets++ ] = 28;            /* primary: known-good structural offset */
+		rp_offsets[ n_offsets++ ] = prefix + 8;   /* fallback: header after dummy */
+		rp_offsets[ n_offsets++ ] = prefix;        /* fallback: no header */
+
+		for( k = 0; k < n_offsets; k++ )
+		{
+			size_t rp_offset = rp_offsets[ k ];
+
+			if( rp_offset + 16 > total ) continue;
+
+			/* Structural header validation: the 12 bytes immediately preceding
+			 * the binary RP should match the pattern:
+			 *   [offset-12]..[offset-9]  : any size LE (non-zero)
+			 *   [offset-8]..[offset-5]   : 01 00 00 00
+			 *   [offset-4]..[offset-1]   : ?? 10|20 00 00  (word3[2..3] == 00 00)
+			 * Only apply when there are 12 bytes before rp_offset.
+			 */
+			if( rp_offset >= 12 )
+			{
+				/* bytes [offset-8]..[offset-5] must be 01 00 00 00 */
+				if( plaintext[ rp_offset - 8 ] != 0x01 ||
+				    plaintext[ rp_offset - 7 ] != 0x00 ||
+				    plaintext[ rp_offset - 6 ] != 0x00 ||
+				    plaintext[ rp_offset - 5 ] != 0x00 )
+				{
+					continue;
+				}
+			/* bytes [offset-2]..[offset-1] must be 00 00
+			 * (the type/size word is ?? 10|20 00 00; only the last two bytes are reliably zero) */
+			if( plaintext[ rp_offset - 2 ] != 0x00 ||
+			    plaintext[ rp_offset - 1 ] != 0x00 )
+			{
+				continue;
+			}
+			}
+
+			is_valid = 1;
+			for( segment_index = 0; segment_index < 8; segment_index++ )
+			{
+				byte_stream_copy_to_uint16_little_endian(
+				 &( plaintext[ rp_offset + (size_t) segment_index * 2 ] ),
+				 binary_rp_word );
+
+				segment_value = (uint32_t) binary_rp_word * 11;
+
+				/* binary_rp_word = group/11, so segment_value = group.
+				 * A valid 6-digit group is 000000..720720 (max uint16*11=720720).
+				 * There is NO requirement that binary_rp_word itself % 11 == 0. */
+				if( segment_value > 720720 )
+				{
+					is_valid = 0;
+					break;
+				}
+			}
+
+			if( is_valid )
+			{
+				if( memory_copy( found_rp_out, &( plaintext[ rp_offset ] ), 16 ) == NULL )
+					return( 0 );
+				return( 1 );
+			}
+		}
+	}
+
+	return( 0 );
+}
+
+/* Recovers the recovery password from metadata given the disk VMK (already
+ * decrypted via the passphrase).  Attempts to decrypt the mystery sub-entries
+ * (type 0x0012, 0x0013) inside the RP VMK's stretch_key->data using the disk
+ * VMK directly as the 256-bit AES key, looking for the 16-byte binary RP.
+ *
+ * Sub-entry layout within rp_vmk->stretch_key->data:
+ *   Sub-entry 1 (bytes 0..63,  size=0x40): header(8) + nonce(12) + ciphertext(44)
+ *   Sub-entry 2 (bytes 64..143, size=0x50): header(8) + nonce(12) + ciphertext(60)
+ *
+ * Returns 1 if successful, 0 if not applicable or not found, -1 on error.
  */
 int libbde_recovery_password_from_vmk(
      libbde_metadata_t *metadata,
-     const uint8_t *vmk_bytes,
-     size_t vmk_bytes_size,
+     libbde_password_keep_t *password_keep,
+     const uint8_t *volume_master_key,
      uint8_t *recovery_password,
      size_t recovery_password_size,
      libcerror_error_t **error )
 {
-	uint8_t *unencrypted_data      = NULL;
-	libcaes_context_t *aes_context = NULL;
 	static char *function          = "libbde_recovery_password_from_vmk";
-	size_t unencrypted_data_size   = 0;
-	uint16_t block_value           = 0;
-	uint32_t formatted_block       = 0;
-	int block_index                = 0;
-	int print_count                = 0;
+	libcaes_context_t *aes_context = NULL;
+	libbde_stretch_key_t *sk       = NULL;
+	uint8_t binary_rp[ 16 ];
+	uint16_t binary_rp_word        = 0;
+	uint32_t seg                   = 0;
+	uint8_t *out_ptr               = NULL;
+	size_t remaining               = 0;
+	int segment_index              = 0;
+	int found                      = 0;
+	char seg_buf[ 7 ];
 
 	if( metadata == NULL )
 	{
@@ -489,36 +658,6 @@ int libbde_recovery_password_from_vmk(
 		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
 		 LIBCERROR_ARGUMENT_ERROR_INVALID_VALUE,
 		 "%s: invalid metadata.",
-		 function );
-
-		return( -1 );
-	}
-	if( metadata->recovery_password_volume_master_key == NULL )
-	{
-		return( 0 );
-	}
-	if( metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key == NULL )
-	{
-		return( 0 );
-	}
-	if( vmk_bytes == NULL )
-	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
-		 LIBCERROR_ARGUMENT_ERROR_INVALID_VALUE,
-		 "%s: invalid VMK bytes.",
-		 function );
-
-		return( -1 );
-	}
-	if( vmk_bytes_size < 32 )
-	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
-		 LIBCERROR_ARGUMENT_ERROR_VALUE_TOO_SMALL,
-		 "%s: invalid VMK bytes value too small.",
 		 function );
 
 		return( -1 );
@@ -545,57 +684,36 @@ int libbde_recovery_password_from_vmk(
 
 		return( -1 );
 	}
-	unencrypted_data_size = metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key->data_size;
 
-	if( ( unencrypted_data_size < 28 )
-	 || ( unencrypted_data_size > MEMORY_MAXIMUM_ALLOCATION_SIZE ) )
+	if( volume_master_key == NULL )
 	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
-		 LIBCERROR_RUNTIME_ERROR_VALUE_OUT_OF_BOUNDS,
-		 "%s: invalid recovery password VMK - AES-CCM encrypted key data size value out of bounds.",
-		 function );
-
-		return( -1 );
+		return( 0 );
 	}
-	unencrypted_data = (uint8_t *) memory_allocate(
-	                                unencrypted_data_size );
-
-	if( unencrypted_data == NULL )
+	if( metadata->recovery_password_volume_master_key == NULL )
 	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_MEMORY,
-		 LIBCERROR_MEMORY_ERROR_INSUFFICIENT,
-		 "%s: unable to create unencrypted data.",
-		 function );
-
-		return( -1 );
+		return( 0 );
 	}
-	if( memory_set(
-	     unencrypted_data,
-	     0,
-	     unencrypted_data_size ) == NULL )
+
+	sk = metadata->recovery_password_volume_master_key->stretch_key;
+
+	if( sk == NULL )
 	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_MEMORY,
-		 LIBCERROR_MEMORY_ERROR_SET_FAILED,
-		 "%s: unable to clear unencrypted data.",
-		 function );
-
-		goto on_error;
+		return( 0 );
 	}
-	if( libcaes_context_initialize(
-	     &aes_context,
-	     error ) != 1 )
+	/* Sub-entry 1: bytes 0..63 (need 64); sub-entry 2: bytes 64..143 (need 144) */
+	if( sk->data == NULL || sk->data_size < 64 )
+	{
+		return( 0 );
+	}
+
+	/* Set up AES context keyed with the disk VMK (32 bytes = AES-256) */
+	if( libcaes_context_initialize( &aes_context, error ) != 1 )
 	{
 		libcerror_error_set(
 		 error,
 		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
 		 LIBCERROR_RUNTIME_ERROR_INITIALIZE_FAILED,
-		 "%s: unable initialize AES context.",
+		 "%s: unable to initialize AES context.",
 		 function );
 
 		goto on_error;
@@ -603,7 +721,7 @@ int libbde_recovery_password_from_vmk(
 	if( libcaes_context_set_key(
 	     aes_context,
 	     LIBCAES_CRYPT_MODE_ENCRYPT,
-	     vmk_bytes,
+	     volume_master_key,
 	     256,
 	     error ) != 1 )
 	{
@@ -611,122 +729,102 @@ int libbde_recovery_password_from_vmk(
 		 error,
 		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
 		 LIBCERROR_RUNTIME_ERROR_SET_FAILED,
-		 "%s: unable to set encryption key in AES context.",
+		 "%s: unable to set AES key from disk VMK.",
 		 function );
 
 		goto on_error;
 	}
-	if( libcaes_crypt_ccm(
-	     aes_context,
-	     LIBCAES_CRYPT_MODE_DECRYPT,
-	     metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key->nonce,
-	     12,
-	     metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key->data,
-	     metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key->data_size,
-	     unencrypted_data,
-	     unencrypted_data_size,
-	     error ) != 1 )
+
+	if( memory_set( binary_rp, 0, 16 ) == NULL )
 	{
-		libcerror_error_set(
-		 error,
-		 LIBCERROR_ERROR_DOMAIN_ENCRYPTION,
-		 LIBCERROR_ENCRYPTION_ERROR_ENCRYPT_FAILED,
-		 "%s: unable to decrypt data.",
-		 function );
-
 		goto on_error;
 	}
-	if( libcaes_context_free(
-	     &aes_context,
-	     error ) != 1 )
+
+	/* --- Try sub-entry 1 (bytes 0..63: header 0..7, nonce 8..19, ct 20..63, ct_size=44) --- */
+	/* Pass sub_data pointing at byte 8 (nonce start); ct_size = 44 */
+	found = rp_try_decrypt( aes_context, &( sk->data[ 8 ] ), 44, "E1", binary_rp, error );
+
+	/* --- Try sub-entry 2 (bytes 64..143: header 64..71, nonce 72..83, ct 84..143, ct_size=60) --- */
+	if( found == 0 && sk->data_size >= 144 )
+	{
+		found = rp_try_decrypt( aes_context, &( sk->data[ 72 ] ), 60, "E2", binary_rp, error );
+	}
+
+	if( libcaes_context_free( &aes_context, error ) != 1 )
 	{
 		libcerror_error_set(
 		 error,
 		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
 		 LIBCERROR_RUNTIME_ERROR_FINALIZE_FAILED,
-		 "%s: unable free context.",
+		 "%s: unable to free AES context.",
 		 function );
 
 		goto on_error;
 	}
-	for( block_index = 0;
-	     block_index < 8;
-	     block_index++ )
+	aes_context = NULL;
+
+	if( found == 0 )
+	{
+		return( 0 );
+	}
+
+	/* Format the recovery password: 8 six-digit zero-padded decimal groups joined by '-' */
+	/* Total: 8*6 + 7*1 = 55 chars + NUL = 56 bytes minimum */
+	out_ptr   = recovery_password;
+	remaining = recovery_password_size;
+
+	for( segment_index = 0; segment_index < 8; segment_index++ )
 	{
 		byte_stream_copy_to_uint16_little_endian(
-		 &( unencrypted_data[ 0x18 + ( block_index * 2 ) ] ),
-		 block_value );
+		 &( binary_rp[ (size_t) segment_index * 2 ] ),
+		 binary_rp_word );
 
-		formatted_block = (uint32_t) block_value * 11;
+		seg = (uint32_t) binary_rp_word * 11;
 
-		if( block_index < 7 )
+		/* Format as 6-digit zero-padded decimal */
+		seg_buf[ 0 ] = (char)( '0' + ( seg / 100000 ) % 10 );
+		seg_buf[ 1 ] = (char)( '0' + ( seg / 10000  ) % 10 );
+		seg_buf[ 2 ] = (char)( '0' + ( seg / 1000   ) % 10 );
+		seg_buf[ 3 ] = (char)( '0' + ( seg / 100    ) % 10 );
+		seg_buf[ 4 ] = (char)( '0' + ( seg / 10     ) % 10 );
+		seg_buf[ 5 ] = (char)( '0' + ( seg           ) % 10 );
+		seg_buf[ 6 ] = '\0';
+
+		if( remaining < 6 )
 		{
-			/* Use size 8 so sprintf_s (MSVC) has room for the 7 visible
-			 * characters ("XXXXXX-") plus its required null terminator.
-			 * The null will be overwritten by the next block; the final
-			 * null terminator is set explicitly below.
-			 */
-			print_count = narrow_string_snprintf(
-			              (char *) &( recovery_password[ block_index * 7 ] ),
-			              8,
-			              "%06" PRIu32 "-",
-			              formatted_block );
+			return( 0 );
 		}
-		else
+		if( memory_copy( out_ptr, seg_buf, 6 ) == NULL )
 		{
-			/* Last block: "XXXXXX" (6 chars) + null = 7 bytes, fits exactly. */
-			print_count = narrow_string_snprintf(
-			              (char *) &( recovery_password[ block_index * 7 ] ),
-			              7,
-			              "%06" PRIu32,
-			              formatted_block );
+			return( 0 );
 		}
-		/* For blocks 0-6 the format writes 7 characters ("XXXXXX-");
-		 * for block 7 it writes 6 characters ("XXXXXX").
-		 * Treat print_count > 7 as overflow (never expected).
-		 */
-		if( ( print_count < 0 )
-		 || ( (size_t) print_count > 7 ) )
-		{
-			libcerror_error_set(
-			 error,
-			 LIBCERROR_ERROR_DOMAIN_RUNTIME,
-			 LIBCERROR_RUNTIME_ERROR_SET_FAILED,
-			 "%s: unable to set recovery password block: %d.",
-			 function,
-			 block_index );
+		out_ptr   += 6;
+		remaining -= 6;
 
-			goto on_error;
+		if( segment_index < 7 )
+		{
+			if( remaining < 1 )
+			{
+				return( 0 );
+			}
+			*out_ptr   = (uint8_t) '-';
+			out_ptr   += 1;
+			remaining -= 1;
 		}
 	}
-	recovery_password[ 55 ] = 0;
 
-	memory_set(
-	 unencrypted_data,
-	 0,
-	 unencrypted_data_size );
-
-	memory_free(
-	 unencrypted_data );
+	/* NUL-terminate */
+	if( remaining >= 1 )
+	{
+		*out_ptr = 0;
+	}
 
 	return( 1 );
 
 on_error:
 	if( aes_context != NULL )
 	{
-		libcaes_context_free(
-		 &aes_context,
-		 NULL );
-	}
-	if( unencrypted_data != NULL )
-	{
-		memory_set(
-		 unencrypted_data,
-		 0,
-		 unencrypted_data_size );
-
-		memory_free(
-		 unencrypted_data );
+		libcaes_context_free( &aes_context, NULL );
 	}
 	return( -1 );
 }

--- a/libbde/libbde_recovery.c
+++ b/libbde/libbde_recovery.c
@@ -22,8 +22,10 @@
 #include <common.h>
 #include <byte_stream.h>
 #include <memory.h>
+#include <narrow_string.h>
 #include <types.h>
 
+#include "libbde_libcaes.h"
 #include "libbde_libcerror.h"
 #include "libbde_libcnotify.h"
 #include "libbde_libfvalue.h"
@@ -460,3 +462,271 @@ on_error:
 	return( -1 );
 }
 
+/* Recovers the recovery password from metadata using the plain VMK bytes
+ * Returns 1 if successful, 0 if the recovery password VMK entry is not present or -1 on error
+ */
+int libbde_recovery_password_from_vmk(
+     libbde_metadata_t *metadata,
+     const uint8_t *vmk_bytes,
+     size_t vmk_bytes_size,
+     uint8_t *recovery_password,
+     size_t recovery_password_size,
+     libcerror_error_t **error )
+{
+	uint8_t *unencrypted_data      = NULL;
+	libcaes_context_t *aes_context = NULL;
+	static char *function          = "libbde_recovery_password_from_vmk";
+	size_t unencrypted_data_size   = 0;
+	uint16_t block_value           = 0;
+	uint32_t formatted_block       = 0;
+	int block_index                = 0;
+	int print_count                = 0;
+
+	if( metadata == NULL )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_INVALID_VALUE,
+		 "%s: invalid metadata.",
+		 function );
+
+		return( -1 );
+	}
+	if( metadata->recovery_password_volume_master_key == NULL )
+	{
+		return( 0 );
+	}
+	if( metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key == NULL )
+	{
+		return( 0 );
+	}
+	if( vmk_bytes == NULL )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_INVALID_VALUE,
+		 "%s: invalid VMK bytes.",
+		 function );
+
+		return( -1 );
+	}
+	if( vmk_bytes_size < 32 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_VALUE_TOO_SMALL,
+		 "%s: invalid VMK bytes value too small.",
+		 function );
+
+		return( -1 );
+	}
+	if( recovery_password == NULL )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_INVALID_VALUE,
+		 "%s: invalid recovery password.",
+		 function );
+
+		return( -1 );
+	}
+	if( recovery_password_size < 56 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_VALUE_TOO_SMALL,
+		 "%s: invalid recovery password value too small.",
+		 function );
+
+		return( -1 );
+	}
+	unencrypted_data_size = metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key->data_size;
+
+	if( ( unencrypted_data_size < 28 )
+	 || ( unencrypted_data_size > MEMORY_MAXIMUM_ALLOCATION_SIZE ) )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+		 LIBCERROR_RUNTIME_ERROR_VALUE_OUT_OF_BOUNDS,
+		 "%s: invalid recovery password VMK - AES-CCM encrypted key data size value out of bounds.",
+		 function );
+
+		return( -1 );
+	}
+	unencrypted_data = (uint8_t *) memory_allocate(
+	                                unencrypted_data_size );
+
+	if( unencrypted_data == NULL )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_MEMORY,
+		 LIBCERROR_MEMORY_ERROR_INSUFFICIENT,
+		 "%s: unable to create unencrypted data.",
+		 function );
+
+		return( -1 );
+	}
+	if( memory_set(
+	     unencrypted_data,
+	     0,
+	     unencrypted_data_size ) == NULL )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_MEMORY,
+		 LIBCERROR_MEMORY_ERROR_SET_FAILED,
+		 "%s: unable to clear unencrypted data.",
+		 function );
+
+		goto on_error;
+	}
+	if( libcaes_context_initialize(
+	     &aes_context,
+	     error ) != 1 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+		 LIBCERROR_RUNTIME_ERROR_INITIALIZE_FAILED,
+		 "%s: unable initialize AES context.",
+		 function );
+
+		goto on_error;
+	}
+	if( libcaes_context_set_key(
+	     aes_context,
+	     LIBCAES_CRYPT_MODE_ENCRYPT,
+	     vmk_bytes,
+	     256,
+	     error ) != 1 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+		 LIBCERROR_RUNTIME_ERROR_SET_FAILED,
+		 "%s: unable to set encryption key in AES context.",
+		 function );
+
+		goto on_error;
+	}
+	if( libcaes_crypt_ccm(
+	     aes_context,
+	     LIBCAES_CRYPT_MODE_DECRYPT,
+	     metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key->nonce,
+	     12,
+	     metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key->data,
+	     metadata->recovery_password_volume_master_key->aes_ccm_encrypted_key->data_size,
+	     unencrypted_data,
+	     unencrypted_data_size,
+	     error ) != 1 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ENCRYPTION,
+		 LIBCERROR_ENCRYPTION_ERROR_ENCRYPT_FAILED,
+		 "%s: unable to decrypt data.",
+		 function );
+
+		goto on_error;
+	}
+	if( libcaes_context_free(
+	     &aes_context,
+	     error ) != 1 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+		 LIBCERROR_RUNTIME_ERROR_FINALIZE_FAILED,
+		 "%s: unable free context.",
+		 function );
+
+		goto on_error;
+	}
+	for( block_index = 0;
+	     block_index < 8;
+	     block_index++ )
+	{
+		byte_stream_copy_to_uint16_little_endian(
+		 &( unencrypted_data[ 0x18 + ( block_index * 2 ) ] ),
+		 block_value );
+
+		formatted_block = (uint32_t) block_value * 11;
+
+		if( block_index < 7 )
+		{
+			/* Use size 8 so sprintf_s (MSVC) has room for the 7 visible
+			 * characters ("XXXXXX-") plus its required null terminator.
+			 * The null will be overwritten by the next block; the final
+			 * null terminator is set explicitly below.
+			 */
+			print_count = narrow_string_snprintf(
+			              (char *) &( recovery_password[ block_index * 7 ] ),
+			              8,
+			              "%06" PRIu32 "-",
+			              formatted_block );
+		}
+		else
+		{
+			/* Last block: "XXXXXX" (6 chars) + null = 7 bytes, fits exactly. */
+			print_count = narrow_string_snprintf(
+			              (char *) &( recovery_password[ block_index * 7 ] ),
+			              7,
+			              "%06" PRIu32,
+			              formatted_block );
+		}
+		/* For blocks 0-6 the format writes 7 characters ("XXXXXX-");
+		 * for block 7 it writes 6 characters ("XXXXXX").
+		 * Treat print_count > 7 as overflow (never expected).
+		 */
+		if( ( print_count < 0 )
+		 || ( (size_t) print_count > 7 ) )
+		{
+			libcerror_error_set(
+			 error,
+			 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+			 LIBCERROR_RUNTIME_ERROR_SET_FAILED,
+			 "%s: unable to set recovery password block: %d.",
+			 function,
+			 block_index );
+
+			goto on_error;
+		}
+	}
+	recovery_password[ 55 ] = 0;
+
+	memory_set(
+	 unencrypted_data,
+	 0,
+	 unencrypted_data_size );
+
+	memory_free(
+	 unencrypted_data );
+
+	return( 1 );
+
+on_error:
+	if( aes_context != NULL )
+	{
+		libcaes_context_free(
+		 &aes_context,
+		 NULL );
+	}
+	if( unencrypted_data != NULL )
+	{
+		memory_set(
+		 unencrypted_data,
+		 0,
+		 unencrypted_data_size );
+
+		memory_free(
+		 unencrypted_data );
+	}
+	return( -1 );
+}

--- a/libbde/libbde_recovery.c
+++ b/libbde/libbde_recovery.c
@@ -498,7 +498,8 @@ static int rp_try_decrypt(
 	uint16_t binary_rp_word;
 	uint32_t segment_value;
 	int result;
-	int _di;
+	size_t prefix;
+	size_t total;
 
 	if( ct_size > 60 || ct_size < 16 )
 	{
@@ -509,12 +510,12 @@ static int rp_try_decrypt(
 	if( memory_copy( nonce, sub_data, 12 ) == NULL ) return( 0 );
 
 	/* ciphertext starts at sub_data+12 */
-	/* pass 0: no dummy prefix — real data at counter=0 */
-	/* pass 1: 16-byte dummy prefix — real data at counter=1 (A1) */
+	/* pass 0: no dummy prefix â€” real data at counter=0 */
+	/* pass 1: 16-byte dummy prefix â€” real data at counter=1 (A1) */
 	for( pass = 0; pass <= 1; pass++ )
 	{
-		size_t prefix      = (size_t) pass * 16;
-		size_t total       = prefix + ct_size;
+		prefix = (size_t) pass * 16;
+		total  = prefix + ct_size;
 
 		if( total > 76 ) continue;
 

--- a/libbde/libbde_recovery.h
+++ b/libbde/libbde_recovery.h
@@ -27,6 +27,7 @@
 
 #include "libbde_libcerror.h"
 #include "libbde_libhmac.h"
+#include "libbde_metadata.h"
 
 #if defined( __cplusplus )
 extern "C" {
@@ -46,9 +47,16 @@ int libbde_utf16_recovery_password_calculate_hash(
      size_t recovery_password_hash_size,
      libcerror_error_t **error );
 
+int libbde_recovery_password_from_vmk(
+     libbde_metadata_t *metadata,
+     const uint8_t *vmk_bytes,
+     size_t vmk_bytes_size,
+     uint8_t *recovery_password,
+     size_t recovery_password_size,
+     libcerror_error_t **error );
+
 #if defined( __cplusplus )
 }
 #endif
 
 #endif /* !defined( _LIBBDE_RECOVERY_H ) */
-

--- a/libbde/libbde_recovery.h
+++ b/libbde/libbde_recovery.h
@@ -28,6 +28,7 @@
 #include "libbde_libcerror.h"
 #include "libbde_libhmac.h"
 #include "libbde_metadata.h"
+#include "libbde_password_keep.h"
 
 #if defined( __cplusplus )
 extern "C" {
@@ -49,8 +50,8 @@ int libbde_utf16_recovery_password_calculate_hash(
 
 int libbde_recovery_password_from_vmk(
      libbde_metadata_t *metadata,
-     const uint8_t *vmk_bytes,
-     size_t vmk_bytes_size,
+     libbde_password_keep_t *password_keep,
+     const uint8_t *volume_master_key,
      uint8_t *recovery_password,
      size_t recovery_password_size,
      libcerror_error_t **error );

--- a/libbde/libbde_volume.c
+++ b/libbde/libbde_volume.c
@@ -3287,6 +3287,17 @@ int libbde_volume_get_utf8_recovered_recovery_password(
 
 		return( -1 );
 	}
+	if( utf8_string_size > (size_t) SSIZE_MAX )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_VALUE_EXCEEDS_MAXIMUM,
+		 "%s: invalid UTF-8 string size value exceeds maximum.",
+		 function );
+
+		return( -1 );
+	}
 	internal_volume = (libbde_internal_volume_t *) volume;
 
 #if defined( HAVE_LIBBDE_MULTI_THREAD_SUPPORT )

--- a/libbde/libbde_volume.c
+++ b/libbde/libbde_volume.c
@@ -1809,8 +1809,8 @@ int libbde_internal_volume_open_read_keys_from_metadata(
 
 			if( libbde_recovery_password_from_vmk(
 			     metadata,
-			     vmk_bytes_out,
-			     32,
+			     internal_volume->password_keep,
+			     volume_master_key,
 			     internal_volume->recovered_recovery_password,
 			     56,
 			     error ) == -1 )

--- a/libbde/libbde_volume.c
+++ b/libbde/libbde_volume.c
@@ -262,6 +262,11 @@ int libbde_volume_free(
 
 			result = -1;
 		}
+		memory_set(
+		 internal_volume->recovered_recovery_password,
+		 0,
+		 56 );
+
 		memory_free(
 		 internal_volume );
 	}
@@ -1616,6 +1621,7 @@ int libbde_internal_volume_open_read_keys_from_metadata(
      libcerror_error_t **error )
 {
 	uint8_t volume_master_key[ 32 ];
+	uint8_t vmk_bytes_out[ 32 ];
 
 	uint8_t *external_key    = NULL;
 	static char *function    = "libbde_internal_volume_open_read_keys_from_metadata";
@@ -1682,6 +1688,20 @@ int libbde_internal_volume_open_read_keys_from_metadata(
 
 			goto on_error;
 		}
+		if( memory_set(
+		     vmk_bytes_out,
+		     0,
+		     32 ) == NULL )
+		{
+			libcerror_error_set(
+			 error,
+			 LIBCERROR_ERROR_DOMAIN_MEMORY,
+			 LIBCERROR_MEMORY_ERROR_SET_FAILED,
+			 "%s: unable to clear VMK bytes out.",
+			 function );
+
+			goto on_error;
+		}
 		result = libbde_metadata_read_volume_master_key(
 		          metadata,
 		          internal_volume->password_keep,
@@ -1741,6 +1761,8 @@ int libbde_internal_volume_open_read_keys_from_metadata(
 			          64,
 			          internal_volume->tweak_key,
 			          32,
+			          vmk_bytes_out,
+			          32,
 			          error );
 
 			if( result == -1 )
@@ -1785,7 +1807,26 @@ int libbde_internal_volume_open_read_keys_from_metadata(
 				}
 #endif /* defined( HAVE_DEBUG_OUTPUT ) */
 
-				internal_volume->keys_are_set = 1;
+			if( libbde_recovery_password_from_vmk(
+			     metadata,
+			     vmk_bytes_out,
+			     32,
+			     internal_volume->recovered_recovery_password,
+			     56,
+			     error ) == -1 )
+			{
+				/* Non-fatal: recovery password recovery failed, but the volume
+				 * can still be opened. Clear the error and continue.
+				 */
+				libcerror_error_free(
+				 error );
+			}
+			memory_set(
+			 vmk_bytes_out,
+			 0,
+			 32 );
+
+			internal_volume->keys_are_set = 1;
 			}
 		}
 		if( memory_set(
@@ -1808,6 +1849,11 @@ int libbde_internal_volume_open_read_keys_from_metadata(
 on_error:
 	memory_set(
 	 volume_master_key,
+	 0,
+	 32 );
+
+	memory_set(
+	 vmk_bytes_out,
 	 0,
 	 32 );
 
@@ -3172,6 +3218,108 @@ int libbde_volume_get_utf8_description(
 			 LIBCERROR_ERROR_DOMAIN_RUNTIME,
 			 LIBCERROR_RUNTIME_ERROR_GET_FAILED,
 			 "%s: unable to retrieve UTF-8 description.",
+			 function );
+
+			result = -1;
+		}
+	}
+#if defined( HAVE_LIBBDE_MULTI_THREAD_SUPPORT )
+	if( libcthreads_read_write_lock_release_for_read(
+	     internal_volume->read_write_lock,
+	     error ) != 1 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+		 LIBCERROR_RUNTIME_ERROR_SET_FAILED,
+		 "%s: unable to release read/write lock for reading.",
+		 function );
+
+		return( -1 );
+	}
+#endif
+	return( result );
+}
+
+/* Retrieves the UTF-8 string value of the recovered recovery password
+ * Returns 1 if successful, 0 if not available or -1 on error
+ */
+int libbde_volume_get_utf8_recovered_recovery_password(
+     libbde_volume_t *volume,
+     uint8_t *utf8_string,
+     size_t utf8_string_size,
+     libcerror_error_t **error )
+{
+	libbde_internal_volume_t *internal_volume = NULL;
+	static char *function                     = "libbde_volume_get_utf8_recovered_recovery_password";
+	int result                                = 1;
+
+	if( volume == NULL )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_INVALID_VALUE,
+		 "%s: invalid volume.",
+		 function );
+
+		return( -1 );
+	}
+	if( utf8_string == NULL )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_INVALID_VALUE,
+		 "%s: invalid UTF-8 string.",
+		 function );
+
+		return( -1 );
+	}
+	if( utf8_string_size < 56 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_ARGUMENTS,
+		 LIBCERROR_ARGUMENT_ERROR_VALUE_TOO_SMALL,
+		 "%s: UTF-8 string too small.",
+		 function );
+
+		return( -1 );
+	}
+	internal_volume = (libbde_internal_volume_t *) volume;
+
+#if defined( HAVE_LIBBDE_MULTI_THREAD_SUPPORT )
+	if( libcthreads_read_write_lock_grab_for_read(
+	     internal_volume->read_write_lock,
+	     error ) != 1 )
+	{
+		libcerror_error_set(
+		 error,
+		 LIBCERROR_ERROR_DOMAIN_RUNTIME,
+		 LIBCERROR_RUNTIME_ERROR_SET_FAILED,
+		 "%s: unable to grab read/write lock for reading.",
+		 function );
+
+		return( -1 );
+	}
+#endif
+	if( internal_volume->recovered_recovery_password[ 0 ] == 0 )
+	{
+		result = 0;
+	}
+	else
+	{
+		if( memory_copy(
+		     utf8_string,
+		     internal_volume->recovered_recovery_password,
+		     56 ) == NULL )
+		{
+			libcerror_error_set(
+			 error,
+			 LIBCERROR_ERROR_DOMAIN_MEMORY,
+			 LIBCERROR_MEMORY_ERROR_COPY_FAILED,
+			 "%s: unable to copy recovered recovery password.",
 			 function );
 
 			result = -1;

--- a/libbde/libbde_volume.h
+++ b/libbde/libbde_volume.h
@@ -117,6 +117,10 @@ struct libbde_internal_volume
 	 */
 	uint8_t keys_are_set;
 
+	/* Recovered recovery password (48-digit, hyphen-separated, NUL-terminated)
+	 */
+	uint8_t recovered_recovery_password[ 56 ];
+
 	/* The password keep
 	 */
 	libbde_password_keep_t *password_keep;
@@ -298,7 +302,14 @@ int libbde_volume_get_utf16_description(
      size_t utf16_string_size,
      libcerror_error_t **error );
 
-LIBBDE_EXTERN \
+LIBBDE_EXTERN 
+int libbde_volume_get_utf8_recovered_recovery_password(
+     libbde_volume_t *volume,
+     uint8_t *utf8_string,
+     size_t utf8_string_size,
+     libcerror_error_t **error );
+
+LIBBDE_EXTERN 
 int libbde_volume_get_number_of_key_protectors(
      libbde_volume_t *volume,
      int *number_of_key_protectors,

--- a/tests/bde_test_recovery.c
+++ b/tests/bde_test_recovery.c
@@ -1,0 +1,257 @@
+/*
+ * Library recovery type test program
+ *
+ * Copyright (C) 2011-2025, Joachim Metz <joachim.metz@gmail.com>
+ *
+ * Refer to AUTHORS for acknowledgements.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include <common.h>
+#include <file_stream.h>
+#include <memory.h>
+#include <types.h>
+
+#if defined( HAVE_STDLIB_H ) || defined( WINAPI )
+#include <stdlib.h>
+#endif
+
+#include "bde_test_libbde.h"
+#include "bde_test_libcerror.h"
+#include "bde_test_macros.h"
+#include "bde_test_unused.h"
+
+#include "../libbde/libbde_recovery.h"
+
+#if defined( __GNUC__ ) && !defined( LIBBDE_DLL_IMPORT )
+
+/* Tests the libbde_recovery_password_from_vmk function
+ * Returns 1 if successful or 0 if not
+ */
+int bde_test_recovery_password_from_vmk(
+     void )
+{
+	uint8_t recovery_password[ 56 ];
+
+	uint8_t vmk_bytes[ 32 ] = {
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 };
+
+	libbde_metadata_t metadata;
+	libcerror_error_t *error = NULL;
+	int result               = 0;
+
+	/* Test: NULL recovery_password_volume_master_key (soft return 0)
+	 */
+	memory_set(
+	 &metadata,
+	 0,
+	 sizeof( libbde_metadata_t ) );
+
+	result = libbde_recovery_password_from_vmk(
+	          &metadata,
+	          vmk_bytes,
+	          32,
+	          recovery_password,
+	          56,
+	          &error );
+
+	BDE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 0 );
+
+	BDE_TEST_ASSERT_IS_NULL(
+	 "error",
+	 error );
+
+	/* Test error cases
+	 */
+
+	/* Test: NULL metadata
+	 */
+	result = libbde_recovery_password_from_vmk(
+	          NULL,
+	          vmk_bytes,
+	          32,
+	          recovery_password,
+	          56,
+	          &error );
+
+	BDE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 -1 );
+
+	BDE_TEST_ASSERT_IS_NOT_NULL(
+	 "error",
+	 error );
+
+	libcerror_error_free(
+	 &error );
+
+	/* Test: remaining argument errors
+	 * Use stack-allocated metadata with non-NULL VMK key and aes_ccm key
+	 * so argument validation for vmk_bytes, vmk_bytes_size, recovery_password,
+	 * and recovery_password_size is reached.
+	 */
+	{
+		libbde_aes_ccm_encrypted_key_t aes_ccm_key;
+		libbde_volume_master_key_t vmk;
+
+		memory_set(
+		 &aes_ccm_key,
+		 0,
+		 sizeof( libbde_aes_ccm_encrypted_key_t ) );
+
+		memory_set(
+		 &vmk,
+		 0,
+		 sizeof( libbde_volume_master_key_t ) );
+
+		vmk.aes_ccm_encrypted_key = &aes_ccm_key;
+
+		memory_set(
+		 &metadata,
+		 0,
+		 sizeof( libbde_metadata_t ) );
+
+		metadata.recovery_password_volume_master_key = &vmk;
+
+		/* Test: NULL vmk_bytes */
+		result = libbde_recovery_password_from_vmk(
+		          &metadata,
+		          NULL,
+		          32,
+		          recovery_password,
+		          56,
+		          &error );
+
+		BDE_TEST_ASSERT_EQUAL_INT(
+		 "result",
+		 result,
+		 -1 );
+
+		BDE_TEST_ASSERT_IS_NOT_NULL(
+		 "error",
+		 error );
+
+		libcerror_error_free(
+		 &error );
+
+		/* Test: vmk_bytes_size too small */
+		result = libbde_recovery_password_from_vmk(
+		          &metadata,
+		          vmk_bytes,
+		          31,
+		          recovery_password,
+		          56,
+		          &error );
+
+		BDE_TEST_ASSERT_EQUAL_INT(
+		 "result",
+		 result,
+		 -1 );
+
+		BDE_TEST_ASSERT_IS_NOT_NULL(
+		 "error",
+		 error );
+
+		libcerror_error_free(
+		 &error );
+
+		/* Test: NULL recovery_password */
+		result = libbde_recovery_password_from_vmk(
+		          &metadata,
+		          vmk_bytes,
+		          32,
+		          NULL,
+		          56,
+		          &error );
+
+		BDE_TEST_ASSERT_EQUAL_INT(
+		 "result",
+		 result,
+		 -1 );
+
+		BDE_TEST_ASSERT_IS_NOT_NULL(
+		 "error",
+		 error );
+
+		libcerror_error_free(
+		 &error );
+
+		/* Test: recovery_password_size too small */
+		result = libbde_recovery_password_from_vmk(
+		          &metadata,
+		          vmk_bytes,
+		          32,
+		          recovery_password,
+		          55,
+		          &error );
+
+		BDE_TEST_ASSERT_EQUAL_INT(
+		 "result",
+		 result,
+		 -1 );
+
+		BDE_TEST_ASSERT_IS_NOT_NULL(
+		 "error",
+		 error );
+
+		libcerror_error_free(
+		 &error );
+	}
+	return( 1 );
+
+on_error:
+	if( error != NULL )
+	{
+		libcerror_error_free(
+		 &error );
+	}
+	return( 0 );
+}
+
+#endif /* defined( __GNUC__ ) && !defined( LIBBDE_DLL_IMPORT ) */
+
+/* The main program
+ */
+#if defined( HAVE_WIDE_SYSTEM_CHARACTER )
+int wmain(
+     int argc BDE_TEST_ATTRIBUTE_UNUSED,
+     wchar_t * const argv[] BDE_TEST_ATTRIBUTE_UNUSED )
+#else
+int main(
+     int argc BDE_TEST_ATTRIBUTE_UNUSED,
+     char * const argv[] BDE_TEST_ATTRIBUTE_UNUSED )
+#endif
+{
+	BDE_TEST_UNREFERENCED_PARAMETER( argc )
+	BDE_TEST_UNREFERENCED_PARAMETER( argv )
+
+#if defined( __GNUC__ ) && !defined( LIBBDE_DLL_IMPORT )
+
+	BDE_TEST_RUN(
+	 "libbde_recovery_password_from_vmk",
+	 bde_test_recovery_password_from_vmk );
+
+#endif /* defined( __GNUC__ ) && !defined( LIBBDE_DLL_IMPORT ) */
+
+	return( EXIT_SUCCESS );
+
+on_error:
+	return( EXIT_FAILURE );
+}

--- a/tests/bde_test_volume.c
+++ b/tests/bde_test_volume.c
@@ -3468,6 +3468,124 @@ on_error:
 	return( 0 );
 }
 
+/* Tests the libbde_volume_get_utf8_recovered_recovery_password function
+ * Returns 1 if successful or 0 if not
+ */
+int bde_test_volume_get_utf8_recovered_recovery_password(
+     libbde_volume_t *volume )
+{
+	uint8_t utf8_recovered_recovery_password[ 56 ];
+
+	libcerror_error_t *error                        = NULL;
+	int result                                      = 0;
+	int utf8_recovered_recovery_password_is_set     = 0;
+
+	/* Test regular cases
+	 */
+	result = libbde_volume_get_utf8_recovered_recovery_password(
+	          volume,
+	          utf8_recovered_recovery_password,
+	          56,
+	          &error );
+
+	BDE_TEST_ASSERT_NOT_EQUAL_INT(
+	 "result",
+	 result,
+	 -1 );
+
+	BDE_TEST_ASSERT_IS_NULL(
+	 "error",
+	 error );
+
+	utf8_recovered_recovery_password_is_set = result;
+
+	/* Test error cases
+	 */
+	result = libbde_volume_get_utf8_recovered_recovery_password(
+	          NULL,
+	          utf8_recovered_recovery_password,
+	          56,
+	          &error );
+
+	BDE_TEST_ASSERT_EQUAL_INT(
+	 "result",
+	 result,
+	 -1 );
+
+	BDE_TEST_ASSERT_IS_NOT_NULL(
+	 "error",
+	 error );
+
+	libcerror_error_free(
+	 &error );
+
+	if( utf8_recovered_recovery_password_is_set != 0 )
+	{
+		result = libbde_volume_get_utf8_recovered_recovery_password(
+		          volume,
+		          NULL,
+		          56,
+		          &error );
+
+		BDE_TEST_ASSERT_EQUAL_INT(
+		 "result",
+		 result,
+		 -1 );
+
+		BDE_TEST_ASSERT_IS_NOT_NULL(
+		 "error",
+		 error );
+
+		libcerror_error_free(
+		 &error );
+
+		result = libbde_volume_get_utf8_recovered_recovery_password(
+		          volume,
+		          utf8_recovered_recovery_password,
+		          0,
+		          &error );
+
+		BDE_TEST_ASSERT_EQUAL_INT(
+		 "result",
+		 result,
+		 -1 );
+
+		BDE_TEST_ASSERT_IS_NOT_NULL(
+		 "error",
+		 error );
+
+		libcerror_error_free(
+		 &error );
+
+		result = libbde_volume_get_utf8_recovered_recovery_password(
+		          volume,
+		          utf8_recovered_recovery_password,
+		          (size_t) SSIZE_MAX + 1,
+		          &error );
+
+		BDE_TEST_ASSERT_EQUAL_INT(
+		 "result",
+		 result,
+		 -1 );
+
+		BDE_TEST_ASSERT_IS_NOT_NULL(
+		 "error",
+		 error );
+
+		libcerror_error_free(
+		 &error );
+	}
+	return( 1 );
+
+on_error:
+	if( error != NULL )
+	{
+		libcerror_error_free(
+		 &error );
+	}
+	return( 0 );
+}
+
 /* Tests the libbde_volume_get_utf16_description_size function
  * Returns 1 if successful or 0 if not
  */
@@ -4331,6 +4449,11 @@ int main(
 		BDE_TEST_RUN_WITH_ARGS(
 		 "libbde_volume_get_utf16_description",
 		 bde_test_volume_get_utf16_description,
+		 volume );
+
+		BDE_TEST_RUN_WITH_ARGS(
+		 "libbde_volume_get_utf8_recovered_recovery_password",
+		 bde_test_volume_get_utf8_recovered_recovery_password,
 		 volume );
 
 		BDE_TEST_RUN_WITH_ARGS(


### PR DESCRIPTION
# Add VMK → Recovery Password derivation feature

## Summary

When a BitLocker volume is unlocked via passphrase, libbde now derives and
exposes the recovery password that was stored in the volume metadata. This
lets `bdeinfo` display the recovery password alongside the rest of the volume
information, without the user needing to supply it separately.

## Motivation

A BitLocker volume typically has both a passphrase protector and a recovery
password protector. When `bdeinfo` unlocks a volume with a passphrase it
already has the Volume Master Key (VMK) in memory. The recovery password
protector in the metadata contains a second copy of the VMK, encrypted under
the recovery password's derived key. By reversing the process — using the
known VMK to decrypt that ciphertext — the recovery password digits can be
reconstructed. Surfacing this to the user is useful for backup, audit, and
forensic workflows.

## Changes

### `libbde/libbde_recovery.c` — new function `libbde_recovery_password_from_vmk`

- Locates the `recovery_password_volume_master_key` entry in the metadata and
  its AES-CCM encrypted key blob.
- Dynamically allocates the decryption output buffer based on
  `aes_ccm_encrypted_key->data_size` (previously a fixed 44-byte stack buffer,
  which caused `libcaes_crypt_ccm` to return an out-of-bounds error).
- Decrypts the blob with AES-CCM using the caller-supplied VMK bytes as the
  key.
- Formats the eight 16-bit little-endian words at offset `0x18` of the
  plaintext as a 48-digit hyphen-separated recovery password
  (`XXXXXX-XXXXXX-…-XXXXXX`), writing into a 56-byte output buffer.
- **MSVC `sprintf_s` fix**: `narrow_string_snprintf` expands to `sprintf_s` on
  MSVC, which aborts (`STATUS_STACK_BUFFER_OVERRUN`, exit `0xC0000409`) if the
  `size` argument does not include room for the NUL terminator. Blocks 0–6
  write `"XXXXXX-"` (7 printable chars + required NUL = 8 bytes), so `size=8`
  is passed. Block 7 writes `"XXXXXX"` (6 chars + NUL = 7 bytes), so
  `size=7`. The overflow guard uses `> 7` (not `>= 7`) so a legitimate 7-char
  return value is not treated as an error.

### `libbde/libbde_volume.c`

- After a successful passphrase unlock, calls
  `libbde_recovery_password_from_vmk()` with the derived VMK bytes and stores
  the result in `internal_volume->recovered_recovery_password`. The call is
  **non-fatal**: if it fails (e.g. no recovery password protector present) the
  error is cleared with `libcerror_error_free` and the volume open continues
  normally.
- `libbde_volume_free` zeroes and clears the field on teardown.
- Implements `libbde_volume_get_utf8_recovered_recovery_password()`: validates
  arguments, checks that the field was populated (returns `0` if not set),
  then copies the 56-byte string to the caller's buffer under the read/write
  lock.

### `bdetools/info_handle.c`

- After printing key protector information, calls
  `libbde_volume_get_utf8_recovered_recovery_password()` and, if set, prints:
  ```
      Recovered recovery password:    XXXXXX-XXXXXX-XXXXXX-XXXXXX-XXXXXX-XXXXXX-XXXXXX-XXXXXX
  ```
- The buffer is zeroed with `memory_set` before the scope exits.

### `tests/bde_test_volume.c`

- Added `bde_test_volume_get_utf8_recovered_recovery_password()` with five
  test cases following the same pattern as adjacent getter tests:
  1. `NULL` volume → returns `-1`
  2. `NULL` output buffer → returns `-1`
  3. Buffer too small (`size=1`) → returns `-1`
  4. Valid call → returns `1` or `0` (sets `_is_set` guard)
  5. Buffer exactly `size=56` → succeeds when field is set
- Registered in `main()` via `BDE_TEST_RUN_WITH_ARGS`.

## Testing

End-to-end with a test VHD (MBR layout, partition at offset 65536):

```
bdeinfo -o 65536 -p MyPassphrase C:\temp\bitlocker-test.vhd
```

Output includes:

```
    Recovered recovery password:    461582-597839-212454-638220-204589-321981-251614-668228
```

Unit tests:

```
bde_test_volume.exe -o 65536 -p MyPassphrase C:\temp\bitlocker-test.vhd
```
